### PR TITLE
remove codesponsor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,5 +21,3 @@ $ thoughts --help
 ## License
 
 MIT © [Adam Harris](https://github.com/agarrharr)
-
-<a href="https://app.codesponsor.io/link/3owRGftAkghuGdjHaa955zEJ/agarrharr/thoughts-cli" rel="nofollow"><img src="https://app.codesponsor.io/embed/3owRGftAkghuGdjHaa955zEJ/agarrharr/thoughts-cli.svg" style="width: 888px; height: 68px;" alt="Sponsor" /></a>


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8